### PR TITLE
検索結果を引き渡せるように、検索ページと結果ページを修正

### DIFF
--- a/news-on-earth/src/views/SearchBox.tsx
+++ b/news-on-earth/src/views/SearchBox.tsx
@@ -1,5 +1,4 @@
 import React, { useState, ChangeEvent } from 'react';
-import { useNavigate } from 'react-router-dom';
 import searchIcon from '../assets/search.svg';
 
 interface SearchBoxProps {
@@ -8,7 +7,6 @@ interface SearchBoxProps {
 
 const SearchBox: React.FC<SearchBoxProps> = ({ onSearchChange }) => {
 	const [searchTerm, setSearchTerm] = useState<string>('');
-	const navigate = useNavigate();
 
 	const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
 		setSearchTerm(e.target.value); //入力変更をリアルタイム検知
@@ -16,7 +14,6 @@ const SearchBox: React.FC<SearchBoxProps> = ({ onSearchChange }) => {
 
 	const handleButtonClick = () => {
 		onSearchChange(searchTerm); // ボタンクリック時に検索処理を実行
-		navigate('/SearchResult'); // useHistoryの代わりにuseNavigateを使用
 	};
 
 	return (

--- a/news-on-earth/src/views/SearchPage.tsx
+++ b/news-on-earth/src/views/SearchPage.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom'; // useNavigate をインポート
 import SearchBox from './SearchBox';
 import Background from './Background';
 
@@ -6,10 +7,31 @@ interface TranslationResponse {
   translated_text: string;
 }
 
-const SearchPage: React.FC = () => {
-  const handleSearch = async (searchTerm: string) => {
-    console.log('検索語:', searchTerm);
+interface Article {
+  headline: string;
+  content: string;
+}
 
+const SearchPage: React.FC = () => {
+  const navigate = useNavigate(); // useNavigate フックの初期化
+  const [keyword, setKeyword] = useState<string>('');
+  const handleSearch = async (searchTerm: string) => {
+
+    console.log('検索語:', searchTerm);
+    setKeyword(searchTerm); // keyword 更新
+
+    const hardcodedArticles: Article[] = [
+      {
+        headline: '固定記事の見出し1',
+        content: '固定記事の内容1...',
+      },
+      {
+        headline: '固定記事の見出し2',
+        content: '固定記事の内容2...',
+      },
+      // 他の固定記事
+    ];
+    
     try {
       const response = await fetch('https://api.news-on-earth.workers.dev/api/translate/', {
         method: 'POST',
@@ -25,9 +47,16 @@ const SearchPage: React.FC = () => {
 
       const result: TranslationResponse = await response.json();
       console.log('翻訳結果:', result.translated_text);
+  
     } catch (error) {
       console.error('APIリクエストエラー:', error);
     }
+    navigate('/SearchResult', { 
+      state: { 
+        keyword: searchTerm, // searchTerm または 'サンプル検索キーワード' を渡す
+        articles: hardcodedArticles // 検索結果の固定記事を渡す
+      } 
+    });
   };
 
   return (

--- a/news-on-earth/src/views/SearchResult.tsx
+++ b/news-on-earth/src/views/SearchResult.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useLocation } from 'react-router-dom'; // useLocation をインポート
 import styles from './SearchResult.module.css';
 import Map from './Map'; // Map コンポーネントをインポート
 
@@ -12,8 +13,12 @@ type SearchResultProps = {
   articles?: Article[];
 };
 
-const SearchResult: React.FC<SearchResultProps> = ({ keyword, articles = [] }) => {
+const SearchResult: React.FC = () => {
+  const location = useLocation();
   const [openArticleIndex, setOpenArticleIndex] = useState<number | null>(null);
+
+  const state = location.state as { keyword: string; articles: Article[] };
+  const { keyword, articles } = state;  
 
   const toggleArticle = (index: number) => {
     setOpenArticleIndex(openArticleIndex === index ? null : index);


### PR DESCRIPTION
検索結果を引き渡せるように修正しました。

主な変更点は以下の通りです。

-  結果ページへの遷移ロジックを、SearchBoxからSearchPageに移動
- SearchPageからキーワードと記事をSearchResultに引き渡すように変更　※現在はAPI呼び出し結果ではなく固定値を設定しています
- SearchResultでキーワードと記事を受け取れるように変更