### PR TITLE
メディア名をクリックすると、/api/kv/を呼び出し、位置情報をコンソールに出力する

### DIFF
--- a/news-on-earth/src/views/SearchPage.tsx
+++ b/news-on-earth/src/views/SearchPage.tsx
@@ -100,7 +100,7 @@ const SearchPage: React.FC = () => {
       {
         headline: '固定記事の見出し1',
         content: '固定記事の内容1...',
-        source: 'BBC',
+        source: 'bbc(ex)',
       },
       {
         headline: '固定記事の見出し2',

--- a/news-on-earth/src/views/SearchResult.tsx
+++ b/news-on-earth/src/views/SearchResult.tsx
@@ -9,6 +9,22 @@ type Article = {
   source: string;
 };
 
+// `value`フィールドのための型
+interface Location {
+  longitude: string;
+  latitude: string;
+}
+
+// KV APIの返却値全体のための型
+interface KVApiResponseItem {
+  key: string;
+  value: string; // JSON文字列としてのLocation
+}
+
+// KV APIの返却値全体を表す配列のための型
+type KVApiResponse = KVApiResponseItem[];
+
+
 const SearchResult: React.FC = () => {
   const location = useLocation();
   const [openArticleIndex, setOpenArticleIndex] = useState<number | null>(null);
@@ -22,6 +38,48 @@ const SearchResult: React.FC = () => {
     setOpenArticleIndex(openArticleIndex === index ? null : index);
   };
 
+    // sourceをクリックしたときに呼び出される関数
+    const handleSourceClick = async (source: string) => {
+      console.log('KVAPI:', source);
+
+      try {
+        // KVからメディアの地図情報を取得
+        const kvResponse = await fetch('https://api.news-on-earth.workers.dev/api/kv/', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+      
+        if (!kvResponse.ok) {
+          throw new Error(`HTTP error! status: ${kvResponse.status}`);
+        }
+      
+        const kvResult: KVApiResponse = await kvResponse.json();
+      // 位置情報の処理など
+      console.log('KV APIの応答:', kvResult);
+      
+      // sourceと一致するアイテムを見つける
+      const matchingItem = kvResult.find(item => item.key === source);
+      if (matchingItem) {
+        try {
+          // value の JSON 文字列を適切に解析する
+          const locationInfo: Location = JSON.parse(matchingItem.value.replace(/\\/g, ""));
+          console.log(`位置情報 (${source}):`, locationInfo);
+        } catch (parseError) {
+          console.error(`JSON解析エラー (${source}):`, matchingItem.value);
+        }
+      } else {
+        console.log(`位置情報が見つかりませんでした (${source})`);
+      }
+      
+
+        
+      } catch (error) {
+        console.error('APIリクエストエラー:', error);
+      }
+    };
+  
   return (
     <div className={styles.container}>
       <div className={styles.leftPanel}>
@@ -33,7 +91,12 @@ const SearchResult: React.FC = () => {
             <div key={index} className={styles.article}>
               <div onClick={() => toggleArticle(index)} className={styles.cardHeader}>
                 <h3 className={styles.headline}>{article.headline}</h3>
-                <span className={styles.source}>{article.source}</span>
+                <span 
+                  className={styles.source}
+                  onClick={() => handleSourceClick(article.source)}
+                >
+                  {article.source}
+                </span>
                 <span className={styles.icon}>
                   {openArticleIndex === index ? '▲' : '▼'}
                 </span>


### PR DESCRIPTION
本来なら、メディア名を引数として、/api/kv/を呼び出した方がよいのかもしれませんが、APIの修正は自分ではすぐできなそうでしたので、ひとまず現在のAPIのままでKVのすべてを取得し、受け取った側でメディア指定でフィルターするようにしました。
また、KVのkeyがダブルコーテーションが入っておらずJSON解析でエラーになったので、KVのデータも直接修正しました（よくなかったらご指摘をお願いします）。