### PR TITLE
APIから取得したメディアの位置情報を地図にわたすように修正

### DIFF
--- a/news-on-earth/src/App.tsx
+++ b/news-on-earth/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
         <Route path={`/SearchPage`} element={<SearchPage />} />
         <Route path={`/SearchResult`} element={<SearchResult />} />
         <Route path={`/Test`} element={<Test />} />
-        <Route path={`/Map`} element={<Map />} />
+        <Route path={`/Map`} element={<Map location={{ lat: 51.505, lng: -0.09 }} />} />
       </Routes>
     </BrowserRouter>
   );

--- a/news-on-earth/src/views/LocationMarker.tsx
+++ b/news-on-earth/src/views/LocationMarker.tsx
@@ -1,17 +1,22 @@
-import React from 'react';
-import { Marker, Popup } from 'react-leaflet';
-import { LatLngLiteral } from 'leaflet';
+import React, { useEffect } from 'react';
+import { Marker, Popup, useMap } from 'react-leaflet';
 
 interface LocationMarkerProps {
-  position: LatLngLiteral | null;
+  position: { lat: number; lng: number };
 }
 
 const LocationMarker: React.FC<LocationMarkerProps> = ({ position }) => {
-  return position ? (
+  const map = useMap();
+
+  useEffect(() => {
+    map.flyTo(position);
+  }, [position, map]);
+
+  return (
     <Marker position={position}>
-      <Popup>You are here</Popup>
+      <Popup>指定された位置</Popup>
     </Marker>
-  ) : null;
+  );
 };
 
 export default LocationMarker;

--- a/news-on-earth/src/views/LocationMarker.tsx
+++ b/news-on-earth/src/views/LocationMarker.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Marker, Popup } from 'react-leaflet';
+import { LatLngLiteral } from 'leaflet';
+
+interface LocationMarkerProps {
+  position: LatLngLiteral | null;
+}
+
+const LocationMarker: React.FC<LocationMarkerProps> = ({ position }) => {
+  return position ? (
+    <Marker position={position}>
+      <Popup>You are here</Popup>
+    </Marker>
+  ) : null;
+};
+
+export default LocationMarker;

--- a/news-on-earth/src/views/Map.tsx
+++ b/news-on-earth/src/views/Map.tsx
@@ -14,7 +14,7 @@ const Map: React.FC<MapProps> = ({ location }) => {
   
   return (
     <div>
-        <MapContainer center={center} zoom={13} />
+      <MapContainer center={center} zoom={13} position={location} />
     </div> 
   );
 };

--- a/news-on-earth/src/views/Map.tsx
+++ b/news-on-earth/src/views/Map.tsx
@@ -3,17 +3,18 @@ import MapContainer from './MapContainer'
 import '../../node_modules/leaflet/dist/leaflet.css'
 
 interface MapProps {
-  location?: { lat: number; lng: number };
+  location: { lat: number; lng: number };
 }
 
 const Map: React.FC<MapProps> = ({ location }) => {
+  console.log('map->', location)
   const defaultCenter = { lat: 51.505, lng: -0.09 }; // デフォルトの中心座標
   const center = location || defaultCenter;
 
   
   return (
     <div>
-      <MapContainer center={center} zoom={13} />
+        <MapContainer center={center} zoom={13} />
     </div> 
   );
 };

--- a/news-on-earth/src/views/MapContainer.tsx
+++ b/news-on-earth/src/views/MapContainer.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
-import { MapContainer as LeafletMap, TileLayer, Marker, Popup } from 'react-leaflet';
+import { MapContainer as LeafletMap, TileLayer } from 'react-leaflet';
+import LocationMarker from './LocationMarker'; // LocationMarker のインポート
 
 interface MapContainerProps {
   center: { lat: number; lng: number };
   zoom: number;
+  position?: { lat: number; lng: number }; // 新しいprops
 }
 
-const MapContainer: React.FC<MapContainerProps> = ({ center, zoom }) => {
+const MapContainer: React.FC<MapContainerProps> = ({ center, zoom, position }) => {
+  console.log('mapcontainer->', center)
   const MapContainerStyle = {
     width: "800px",
     height: "800px"
@@ -18,11 +21,24 @@ const MapContainer: React.FC<MapContainerProps> = ({ center, zoom }) => {
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
-      <Marker position={center}>
-        <Popup>Location</Popup>
-      </Marker>
+      {position && <LocationMarker position={position} />} // 位置情報があれば LocationMarker を表示
     </LeafletMap>
   );
 };
+
+// MapContainer.tsx
+// interface LocationMarkerProps {
+//   position: { lat: number; lng: number } | null;
+// }
+
+// const LocationMarker: React.FC<LocationMarkerProps> = ({ position }) => {
+//   if (position === null) return null;
+
+//   return (
+//     <Marker position={position}>
+//       <Popup>指定された位置</Popup>
+//     </Marker>
+//   );
+// };
 
 export default MapContainer;

--- a/news-on-earth/src/views/MapContainer.tsx
+++ b/news-on-earth/src/views/MapContainer.tsx
@@ -9,7 +9,8 @@ interface MapContainerProps {
 }
 
 const MapContainer: React.FC<MapContainerProps> = ({ center, zoom, position }) => {
-  console.log('mapcontainer->', center)
+  console.log('mapcontainer center->', center)
+  console.log('mapcontainer position->', position)
   const MapContainerStyle = {
     width: "800px",
     height: "800px"
@@ -21,24 +22,10 @@ const MapContainer: React.FC<MapContainerProps> = ({ center, zoom, position }) =
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
-      {position && <LocationMarker position={position} />} // 位置情報があれば LocationMarker を表示
+      {position && <LocationMarker position={position} />}
+
     </LeafletMap>
   );
 };
-
-// MapContainer.tsx
-// interface LocationMarkerProps {
-//   position: { lat: number; lng: number } | null;
-// }
-
-// const LocationMarker: React.FC<LocationMarkerProps> = ({ position }) => {
-//   if (position === null) return null;
-
-//   return (
-//     <Marker position={position}>
-//       <Popup>指定された位置</Popup>
-//     </Marker>
-//   );
-// };
 
 export default MapContainer;

--- a/news-on-earth/src/views/SearchPage.tsx
+++ b/news-on-earth/src/views/SearchPage.tsx
@@ -105,7 +105,7 @@ const SearchPage: React.FC = () => {
       {
         headline: '固定記事の見出し2',
         content: '固定記事の内容2...',
-        source: 'WSJ',
+        source: 'cnn(ex)',
       },
     ];
     //TODO:仮表示のため、削除

--- a/news-on-earth/src/views/SearchResult.tsx
+++ b/news-on-earth/src/views/SearchResult.tsx
@@ -28,6 +28,8 @@ type KVApiResponse = KVApiResponseItem[];
 const SearchResult: React.FC = () => {
   const location = useLocation();
   const [openArticleIndex, setOpenArticleIndex] = useState<number | null>(null);
+  const [mapLocation, setMapLocation] = useState<{ lat: number; lng: number }>({ lat: 0, lng: 0 }); // 初期値を { lat: 0, lng: 0 } に設定
+
 
   // location.state に基づいて型付けされた変数を作成
   const state = location.state as { keyword?: string; articles?: Article[] } | null;
@@ -66,6 +68,12 @@ const SearchResult: React.FC = () => {
           // value の JSON 文字列を適切に解析する
           const locationInfo: Location = JSON.parse(matchingItem.value.replace(/\\/g, ""));
           console.log(`位置情報 (${source}):`, locationInfo);
+          setMapLocation({
+            lat: parseFloat(locationInfo.latitude),
+            lng: parseFloat(locationInfo.longitude)
+          });
+          console.log('SearchResult->', mapLocation)
+
         } catch (parseError) {
           console.error(`JSON解析エラー (${source}):`, matchingItem.value);
         }
@@ -73,7 +81,6 @@ const SearchResult: React.FC = () => {
         console.log(`位置情報が見つかりませんでした (${source})`);
       }
       
-
         
       } catch (error) {
         console.error('APIリクエストエラー:', error);
@@ -111,7 +118,7 @@ const SearchResult: React.FC = () => {
         </div>
       </div>
       <div className={styles.rightPanel}>
-        <Map />
+      <Map location={mapLocation} />
       </div>
     </div>
   );

--- a/news-on-earth/src/views/SearchResult.tsx
+++ b/news-on-earth/src/views/SearchResult.tsx
@@ -28,8 +28,7 @@ type KVApiResponse = KVApiResponseItem[];
 const SearchResult: React.FC = () => {
   const location = useLocation();
   const [openArticleIndex, setOpenArticleIndex] = useState<number | null>(null);
-  const [mapLocation, setMapLocation] = useState<{ lat: number; lng: number }>({ lat: 0, lng: 0 }); // 初期値を { lat: 0, lng: 0 } に設定
-
+  const [mapLocation, setMapLocation] = useState<{ lat: number; lng: number }>({ lat: 35.6894, lng: 139.6917 });
 
   // location.state に基づいて型付けされた変数を作成
   const state = location.state as { keyword?: string; articles?: Article[] } | null;


### PR DESCRIPTION
APIから取得したメディアの位置情報を地図にわたすように修正しました。
以下の通り、MapContainerまでKVからAPIで取得した位置情報が渡っているのですが、肝心に地図に反映されません。再描画が必要なのかなど調べているところですが、いったんPRを出させていただきます。
もし何かお気づきのことがあれば教えていただけますでしょうか。
よろしくお願いします。

<img width="1488" alt="スクリーンショット 2024-01-13 12 21 52" src="https://github.com/jun-koyama-h/team_project/assets/79067302/d5bf539c-2daf-4b9a-aef0-321bbb903feb">
